### PR TITLE
The new version of typeahead changed the behavior of returning the empty set. 

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,12 +29,6 @@ $("document").ready(function() {
       // an array that will be populated with substring matches
       matches = [];
 
-      var startingtext = /^[Rr]72\s*$/;
-      if (startingtext.test(q)) {
-        clearMarkers();
-        return; 
-      }
-
       // regex used to determine if a string contains the substring `q`
       substrRegex = new RegExp(q, 'i');
   


### PR DESCRIPTION
If the search matches 'R72 ', the new version of typeahead returns the no results found message. The previous version of the plug in returned the whole dataset if no result set was returned.

Removing the check corrects the new behavior.
